### PR TITLE
Fix to add support for PostgreSQL 9.5.

### DIFF
--- a/methods/array_ops/src/pg_gp/array_ops.sql_in
+++ b/methods/array_ops/src/pg_gp/array_ops.sql_in
@@ -602,11 +602,13 @@ m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `NO SQL', `');
  *        in later GPDB and Postgres versions.
  */
 DROP AGGREGATE IF EXISTS MADLIB_SCHEMA.array_agg(anyelement) CASCADE;
+/*
 CREATE AGGREGATE MADLIB_SCHEMA.array_agg( anyelement) (
    SFUNC     = array_append,
    STYPE     = anyarray
    m4_ifdef( `__POSTGRESQL__', `', `, PREFUNC   = array_cat')
 );
+*/
 
 /**
  * @brief Function to check if array contains NULL.

--- a/src/ports/postgres/9.5/CMakeLists.txt
+++ b/src/ports/postgres/9.5/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_current_postgresql_version()
+add_extension_support()

--- a/src/ports/postgres/cmake/FindPostgreSQL_9_5.cmake
+++ b/src/ports/postgres/cmake/FindPostgreSQL_9_5.cmake
@@ -1,0 +1,2 @@
+set(_FIND_PACKAGE_FILE "${CMAKE_CURRENT_LIST_FILE}")
+include("${CMAKE_CURRENT_LIST_DIR}/FindPostgreSQL.cmake")

--- a/src/ports/postgres/modules/lda/lda.py_in
+++ b/src/ports/postgres/modules/lda/lda.py_in
@@ -901,8 +901,8 @@ def _convert_data_table(schema_madlib, data_table):
                 SELECT
                     docid,
                     sum(count) wordcount,
-                    {schema_madlib}.array_agg(wordid) words,
-                    {schema_madlib}.array_agg(count) counts
+                    array_agg(wordid) words,
+                    array_agg(count) counts
                 FROM
                     {data_table}
                 WHERE


### PR DESCRIPTION
- Fix to add cmake related files for PostgreSQL 9.5.
- Fix to drop madlib.array_agg() function.
  
  With PostgreSQL 9.5, having madlib.array_agg(anyelement) causes
  the SQL error because pg_catalog.array_agg() has modified to
  support "anyarray" as the argument at 9.5 (and later).
